### PR TITLE
Add error rule "no-return-await"

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
     "no-unneeded-ternary": "error",
     "no-unused-vars": ["error", { args: "none" }],
     "no-var": "warn",
+    "no-return-await": "error",
     "object-shorthand": "warn",
     "prefer-const": "warn",
     "max-lines": ["warn", { skipBlankLines: true, skipComments: true }],


### PR DESCRIPTION
We have many occurrences in our code where we use return await.
This unnecessarily awaits a promise before returning it by the callee, since we already await the promise by the caller.
Therefor we should return the promise without await.